### PR TITLE
chore: `--no-refresh` support when copying state (applies to `av create` && `av copy-state`)

### DIFF
--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionRefreshOptions.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/cli/mixin/SSCAppVersionRefreshOptions.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright 2021, 2023 Open Text.
+ *
+ * The only warranties for products and services of Open Text 
+ * and its affiliates and licensors ("Open Text") are as may 
+ * be set forth in the express warranty statements accompanying 
+ * such products and services. Nothing herein should be construed 
+ * as constituting an additional warranty. Open Text shall not be 
+ * liable for technical or editorial errors or omissions contained 
+ * herein. The information contained herein is subject to change 
+ * without notice.
+ *******************************************************************************/
+package com.fortify.cli.ssc.appversion.cli.mixin;
+
+import com.fortify.cli.common.cli.mixin.CommonOptionMixins;
+import lombok.Getter;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+@Getter
+public class SSCAppVersionRefreshOptions {
+    @Option(names = "--refresh", negatable = true, descriptionKey = "fcli.ssc.appversion.create.refresh",
+            defaultValue = "true", fallbackValue = "true")
+    private boolean refresh;
+}

--- a/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyFromBuilder.java
+++ b/fcli-core/fcli-ssc/src/main/java/com/fortify/cli/ssc/appversion/helper/SSCAppVersionCreateCopyFromBuilder.java
@@ -62,11 +62,7 @@ public final class SSCAppVersionCreateCopyFromBuilder {
         if(!copyState || !copyRequested){
             return null;
         }
-        // refreshMetrics if the source PV is required to fully copy the tags, audit or comments
-        if(this.previousProjectVersion.isRefreshRequired()){
-            SSCJobDescriptor refreshJobDesc = SSCAppVersionHelper.refreshMetrics(unirest, this.previousProjectVersion);
-            SSCJobHelper.waitForJob(unirest,refreshJobDesc);
-        }
+
         this.copyStateOptions.put("projectVersionId", projectVersionId);
         return unirest
                 .post(SSCUrls.PROJECT_VERSIONS_ACTION_COPY_CURRENT_STATE)

--- a/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
+++ b/fcli-core/fcli-ssc/src/main/resources/com/fortify/cli/ssc/i18n/SSCMessages.properties
@@ -228,6 +228,8 @@ fcli.ssc.appversion.create.active = Specify whether application version should b
   or not (false).
 fcli.ssc.appversion.create.skip-if-exists = Skip application version creation if an application version with \
   the specified name already exists.
+fcli.ssc.appversion.create.refresh = By default, this command will refresh the  source application version's metrics when copying from it. \
+  Note that for large applications this can lead to an error if the timeout expires.
 fcli.ssc.appversion.create.copy-options = Comma separated list of elements to copy (Requires --copy-from). By default, all are copied. \
   Allowed values: ${COMPLETION-CANDIDATES}.
 fcli.ssc.appversion.delete.usage.header = Delete an application version.


### PR DESCRIPTION
chore: `--no-refresh` support when copying state (applies to `av create` && `av copy-state`)